### PR TITLE
CM-2374 - Fix autoloaded module

### DIFF
--- a/lib/global_session/session/v2.rb
+++ b/lib/global_session/session/v2.rb
@@ -22,6 +22,9 @@
 # Standard library dependencies
 require 'set'
 
+# Cryptographical Hash
+require 'right_support/crypto'
+
 module GlobalSession::Session
   # Global session V2 uses msgpack serialization and no compression. Its msgpack structure is an
   # Array with the following format:

--- a/lib/global_session/session/v3.rb
+++ b/lib/global_session/session/v3.rb
@@ -22,6 +22,9 @@
 # Standard library dependencies
 require 'set'
 
+# Cryptographical Hash
+require 'right_support/crypto'
+
 module GlobalSession::Session
   # Global session V3 uses JSON serialization, no compression, and a detached signature that is
   # excluded from the JSON structure for efficiency reasons.
@@ -123,14 +126,14 @@ module GlobalSession::Session
         @dirty_secure = true if @signed.keys.include? key
         value = @signed.delete(key)
       elsif @schema_insecure.include?(key)
-        
+
         # Only mark dirty if the key actually exists
         @dirty_insecure = true if @insecure.keys.include? key
         value = @insecure.delete(key)
       else
         raise ArgumentError, "Attribute '#{key}' is not specified in global session configuration"
       end
-      
+
       return value
     end
 


### PR DESCRIPTION
**Please do not merge yet**

Not doing this can result in strange race conditions with apps that consume the 'global_session' library, such as the below error:
```
E, [2016-08-19T23:47:31.498648 #478] ERROR -- : app error: uninitialized constant RightSupport::Crypto::SignedHash (NameError)```
